### PR TITLE
Update Reference in 带限矩阵方程组求解.md

### DIFF
--- a/OJ/带限矩阵方程组求解.md
+++ b/OJ/带限矩阵方程组求解.md
@@ -273,4 +273,4 @@ int main() {
 
 [3]: https://blog.csdn.net/wxkhturfun/article/details/125023717
 
-[4]: https://docs.panxuc.com/projects/coursework/daa/ans/2023207/
+[4]: https://docs.panxuc.com/coursework/daa/ans/2023207/


### PR DESCRIPTION
https://docs.panxuc.com/ has adjusted the structure of the docs, and the maintainer seems not willing to add redirects.